### PR TITLE
Update file_cnab240_parser.py

### DIFF
--- a/l10n_br_cnab_import/file_cnab240_parser.py
+++ b/l10n_br_cnab_import/file_cnab240_parser.py
@@ -79,7 +79,7 @@ class Cnab240Parser(object):
                 transacoes.append({
                     'name': evento.sacado_nome,
                     'date': datetime.datetime.strptime(
-                        str(evento.vencimento_titulo), '%d%m%Y'),
+                        str(evento.vencimento_titulo).zfill(8), '%d%m%Y'),
                     'amount': evento.valor_titulo,
                     'ref': evento.numero_documento,
                     'label': evento.sacado_inscricao_numero,  # cnpj
@@ -91,7 +91,7 @@ class Cnab240Parser(object):
                 res.append({
                     'name': evento.sacado_nome,
                     'date': datetime.datetime.strptime(
-                        str(evento.vencimento_titulo), '%d%m%Y'),
+                        str(evento.vencimento_titulo).zfill(8), '%d%m%Y'),
                     'amount': evento.valor_titulo,
                     'ref': evento.numero_documento,
                     'label': evento.sacado_inscricao_numero,  # cnpj


### PR DESCRIPTION
Use .zfill(8) on date, because it ignores the leading zeros hence gets wrong date, becasue in library dates are read as numbers , "formato": "num"
Eg:

>>> date='3012017'
>>> datetime.datetime.strptime(date,'%d%m%Y').date()
datetime.date(2017, 1, 30)
>>> date='03012017'
>>> datetime.datetime.strptime(date,'%d%m%Y').date()
datetime.date(2017, 1, 3)