### PR TITLE
[8.0][DEVELOP] Estou removendo o dominio do campo payment_mode_id

### DIFF
--- a/l10n_br_account_payment_mode/models/__init__.py
+++ b/l10n_br_account_payment_mode/models/__init__.py
@@ -5,3 +5,4 @@
 from . import payment_mode
 from . import res_bank
 from . import res_partner_bank
+from . import account_invoice

--- a/l10n_br_account_payment_mode/models/account_invoice.py
+++ b/l10n_br_account_payment_mode/models/account_invoice.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 207 Akretion - Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    payment_mode_id = fields.Many2one(
+        comodel_name='payment.mode', string="Payment Mode",)
+


### PR DESCRIPTION
EStou removendo o dominio do campo payment_mode_id porque parece se tratar de cadastros diferentes no objeto payment.mode esse campo é referente ao objeto payment.mode.type mas no objeto account.invoice o campo type é um campo do tipo seleção ( out_invoice, in_invoice, out_refund e in_refund ).

cc @rvalyi @renatonlima @mileo 