### PR TITLE
[8.0][DEVELOP] Inclui o campo payment_mode_id na visão da NF-e.

### DIFF
--- a/l10n_br_account_payment_mode/__openerp__.py
+++ b/l10n_br_account_payment_mode/__openerp__.py
@@ -12,12 +12,14 @@
     "website": "https://odoo-community.org/",
     'depends': [
         'l10n_br_data_base',
+        'l10n_br_account_product',
         'account_due_list_payment_mode',
         'account_banking_payment_export',
         'l10n_br_account_banking_payment',
     ],
     'data': [
         'views/payment_mode_view.xml',
+        'views/account_invoice_view.xml',
     ],
     'demo': [
         'demo/payment_demo.xml'

--- a/l10n_br_account_payment_mode/views/account_invoice_view.xml
+++ b/l10n_br_account_payment_mode/views/account_invoice_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="l10n_br_account_payment_mode_invoice_form" model="ir.ui.view">
+            <field name="name">l10n_br_account_payment_mode.invoice.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="l10n_br_account_product.l10n_br_account_product_nfe_form"/>
+            <field name="arch" type="xml">
+                <field name="payment_term" position="after">
+                    <field name="payment_mode_id" domain="[('active', '=', True)]" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+


### PR DESCRIPTION
É necessário verificar se esse seria o modulo correto para incluir essa visão, já que também foi preciso incluir a dependencia do modulo l10n_br_account_product 

cc @renatonlima @rvalyi @mileo 