### PR TITLE
[8.0[DEVELOP] O campo internal_sequence_id quando vazio causa erro no PyBoleto

### DIFF
--- a/l10n_br_account_payment_boleto/demo/payment_demo.xml
+++ b/l10n_br_account_payment_boleto/demo/payment_demo.xml
@@ -86,6 +86,7 @@
             <field name="boleto_convenio">99999999</field>
             <field name="boleto_carteira">109</field>
             <field name="boleto_modalidade">DM</field>
+            <field name="internal_sequence_id" ref="sequence_boleto_own_number"/>
             <!--<field name="boleto_variacao">19</field>-->
             <!--<field name="aceite">N</field>-->
         </record>

--- a/l10n_br_account_payment_mode/views/payment_mode_view.xml
+++ b/l10n_br_account_payment_mode/views/payment_mode_view.xml
@@ -42,7 +42,7 @@
                             </page>
                             <page string="Pagamento" attrs="{'invisible': [('purchase_ok', '!=', True)]}">
                                 <group>
-                                    <field name="internal_sequence_id"/>
+                                    <field name="internal_sequence_id" required='True'/>
                                     <field name="instrucoes"
                                            attrs="{'invisible': [('payment_order_type', '!=', 'cobranca')]}"/>
                                     <field name="invoice_print"


### PR DESCRIPTION
Verificar se esse campo deve ser obrigatorio já que em l10n_br_account_payment_boleto/models/account_move_line.py na linha 60

                            nosso_numero = self.env['ir.sequence'].next_by_id(
                                move_line.payment_mode_id.
                                internal_sequence_id.id)

Esse campo é buscado e se é retornado False isso causa erro no PyBoleto.

2017-08-24 19:48:40,248 1346 ERROR boleto1 openerp.addons.l10n_br_account_payment_boleto.models.account_move_line: invalid literal for int() with base 10: 'e'
Traceback (most recent call last):
  File "/workspace/parts/odoo-brazil-banking-commit/l10n_br_account_payment_boleto/models/account_move_line.py", line 69, in send_payment
    boleto.boleto.format_nosso_numero()
  File "/home/magno/.voodoo/shared/eggs/pyboleto-0.3.1-py2.7.egg/pyboleto/bank/itau.py", line 56, in format_nosso_numero
    self.dv_nosso_numero)
  File "/home/magno/.voodoo/shared/eggs/pyboleto-0.3.1-py2.7.egg/pyboleto/bank/itau.py", line 39, in dv_nosso_numero
    return self.modulo10(composto)
  File "/home/magno/.voodoo/shared/eggs/pyboleto-0.3.1-py2.7.egg/pyboleto/data.py", line 461, in modulo10
    parcial = int(c) * peso
ValueError: invalid literal for int() with base 10: 'e'

cc @renatonlima @rvalyi @mileo 