### PR TITLE
[8.0][DEVELOP] Develop descomentado arquivos banking payment cnab

### DIFF
--- a/l10n_br_account_banking_payment_cnab/__openerp__.py
+++ b/l10n_br_account_banking_payment_cnab/__openerp__.py
@@ -55,7 +55,7 @@
         'security/ir.model.access.csv',
     ],
     'demo': [
-        # 'demo/l10n_br_payment_mode.xml',
+        'demo/l10n_br_payment_mode.xml',
     ],
     'test': [
         # 'tests/invoice_create.yml'

--- a/l10n_br_account_banking_payment_cnab/models/__init__.py
+++ b/l10n_br_account_banking_payment_cnab/models/__init__.py
@@ -9,5 +9,5 @@ from . import res_partner_bank
 from . import res_partner
 from .. import constantes
 from . import payment_line
-# from . import bank_payment_line
+from . import bank_payment_line
 from . import l10n_br_cnab


### PR DESCRIPTION
Precisei descomentar o dado de demonstração para usa-lo nos testes do BRCobrança e o arquivo python por estar criando um campo usado.

Error details:
Field `codigo_finalidade_complementar` does not exist

É preciso saber porque esses arquivos foram comentados e que erros eles estavam causando.

cc @rvalyi @renatonlima @mileo 