### PR TITLE
[8.0][DEVELOP] domain-manipulation-guards.

### DIFF
--- a/l10n_br_account_banking_payment_cnab/wizard/payment_order_create.py
+++ b/l10n_br_account_banking_payment_cnab/wizard/payment_order_create.py
@@ -38,14 +38,16 @@ class PaymentOrderCreate(models.TransientModel):
                 domain += [
                     ('debit', '>', 0)
                 ]
-            # TODO: Refactory this
-            index = domain.index(('invoice.payment_mode_id', '=', False))
-            del domain[index - 1]
-            domain.remove(('invoice.payment_mode_id', '=', False))
-            index = domain.index(('date_maturity', '<=', self.duedate))
-            del domain[index - 1]
-            domain.remove(('date_maturity', '=', False))
-            domain.remove(('date_maturity', '<=', self.duedate))
+
+            # TODO: Refactor this
+            if ('invoice.payment_mode_id', '=', False) in domain:
+                domain.remove(('invoice.payment_mode_id', '=', False))
+            if ('date_maturity', '<=', self.duedate) in domain:
+                domain.remove(('date_maturity', '<=', self.duedate))
+            if ('date_maturity', '=', False) in domain:
+                domain.remove(('date_maturity', '=', False))
+            if ('date_maturity', '<=', self.duedate) in domain:
+                domain.remove(('date_maturity', '<=', self.duedate))
 
         elif payment_order.mode.type.code == '400':
             if payment_order.mode.payment_order_type == 'cobranca':


### PR DESCRIPTION
Isso foi feito pelo @rvalyi para evitar o erro 

2017-08-25 16:00:36,307 1712 DEBUG cnab openerp.tools.yaml_import: Exception during evaluation of !python block in yaml_file /workspace/parts/odoo-boleto-cnab-commit/l10n_br_account_payment_cnab_brcobranca/tests/invoice_create.yml.
Traceback (most recent call last):
  File "/workspace/parts/odoo/openerp/tools/yaml_import.py", line 588, in process_python
    unsafe_eval(code_obj, {'ref': self.get_id}, code_context)
  File "/workspace/parts/odoo-boleto-cnab-commit/l10n_br_account_payment_cnab_brcobranca/tests/invoice_create.yml", line 132, in <module>
    "active_id": ref("cobranca"), })
  File "/workspace/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/workspace/parts/odoo/openerp/api.py", line 399, in old_api
    result = method(recs, *args, **kwargs)
  File "/workspace/parts/odoo-brazil-banking-commit/l10n_br_account_banking_payment/wizard/payment_order_create.py", line 113, in search_entries
    self.extend_payment_order_domain(payment, domain)
  File "/workspace/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/workspace/parts/odoo-brazil-banking-commit/l10n_br_account_banking_payment_cnab/wizard/payment_order_create.py", line 42, in extend_payment_order_domain
    index = domain.index(('invoice.payment_mode_id', '=', False))
ValueError: ('invoice.payment_mode_id', '=', False) is not in list

cc @renatonlima @mileo 