### PR TITLE
[8.0][DEVELOP] Incluido o campo payment_type na visão do Modo de Pagamento.

### DIFF
--- a/l10n_br_account_payment_mode/views/payment_mode_view.xml
+++ b/l10n_br_account_payment_mode/views/payment_mode_view.xml
@@ -12,6 +12,7 @@
 
                 <field name="type" position="after">
                     <field name="payment_order_type"/>
+                    <field name="type_payment"/>
                 </field>
                 <xpath expr="//form/group[@string='Note']" position="before">
                     <group string="Configurações" name='l10n-br-config' col="4">


### PR DESCRIPTION
O usuario precisa de acesso para selecionar esse campo, sem isso ao criar um novo modo de pagamento o programa usa por padrão '99 - Outros'  o que gera erro se esse novo modo de pagamento for referente a Boleto Bancario porque ao imprimir um boleto é esperado que esse campo seja '00 - Duplicata'

cc @renatonlima @rvalyi @mileo  