### PR TITLE
[8.0[DEVELOP] Retirado caracteres diferente de numeros do campo nosso_numero

### DIFF
--- a/l10n_br_account_payment_boleto/models/account_move_line.py
+++ b/l10n_br_account_payment_boleto/models/account_move_line.py
@@ -62,6 +62,8 @@ class AccountMoveLine(models.Model):
                     else:
                         nosso_numero = move_line.boleto_own_number
 
+                    nosso_numero = int(''.join(
+                        i for i in nosso_numero if i.isdigit()))
                     boleto = Boleto.getBoleto(move_line, nosso_numero)
                     if boleto:
                         move_line.date_payment_created = date.today()


### PR DESCRIPTION
O PyBoleto espera que o campo nosso_numero tenha apenas numeros, como esse campo pode ser preenchido com valores do objeto ir.sequence podem aparecer caracteres com "/", "-", etc ( ex.: 2017/015 ), assim é preciso remove-los

cc @renatonlima @rvalyi @mileo 